### PR TITLE
Deep Structure Handlers

### DIFF
--- a/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
+++ b/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
@@ -152,7 +152,7 @@ public class RFCMetaDataParser {
 
 					processStructure(childElement, jcoStructureInner, structureName);
 				} else if (qname.equals("table")) {
-					String name = childElement.getAttributeValue(new QName("name"));
+					String name = childElement.getAttributeValue(RFCConstants.NAME_Q);
 					JCoTable jcoTableInner = jcoStrcture.getTable(name);
 					processTable(childElement, jcoTableInner);
 				} else {
@@ -199,7 +199,7 @@ public class RFCMetaDataParser {
 
 					processStructure(childElement, jcoStructureInner, structureName);
 				} else if (qname.equals("table")) {
-					String tableName = childElement.getAttributeValue(new QName("name"));
+					String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
 					JCoTable jcoTableInner = jcoStrcture.getTable(tableName);
 
 					if (jcoTableInner == null) {
@@ -219,13 +219,14 @@ public class RFCMetaDataParser {
 		}
 	}
 
-	private static void processTable(OMElement element, JCoTable jconTable) {
+	private static void processTable(OMElement element, JCoTable jconTable) 
+			throws AxisFault{
 		JCoTable inputTable = jconTable;
 		Iterator itr = element.getChildElements();
 		while (itr.hasNext()) {
 			OMElement childElement = (OMElement) itr.next();
 			String qname = childElement.getQName().toString();
-			String id = childElement.getAttributeValue(new QName("id"));
+			String id = childElement.getAttributeValue(RFCConstants.ID_Q);
 			if (qname.equals("row")) {
 				processRow(childElement, inputTable, id);
 			}
@@ -351,7 +352,7 @@ public class RFCMetaDataParser {
             if (qname != null && qname.equals("field")) {
                 processField(childElement, table);
             } else if (qname != null && qname.equals("structure")) {
-				String structureName = childElement.getAttributeValue(new QName("name"));
+				String structureName = childElement.getAttributeValue(RFCConstants.NAME_Q);
 				JCoStructure jcoStrctureInner = table.getStructure(structureName);
 				
 				if (jcoStrctureInner != null) {

--- a/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
+++ b/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
@@ -26,224 +26,305 @@ import org.apache.commons.logging.LogFactory;
 
 import java.util.Iterator;
 
-/** This will contain the required methods that can be use to parser a
- * meta data description of a BAPI/RFC call.
- * So the BNF grammer for the meta data would looks like :
- *  bapirfc   -> import | tables | both
- *  import    -> structure | field | tables | all
- *  structure -> 1 or more fields
- *  tables    -> 1 or more table
- *  table     -> row
- *  row       -> 1 or more fields
- *  field     -> name and value
+/**
+ * This will contain the required methods that can be use to parser a meta data
+ * description of a BAPI/RFC call. So the BNF grammer for the meta data would
+ * looks like : bapirfc -> import | tables | both import -> structure | field |
+ * tables | all structure -> 1 or more fields tables -> 1 or more table table ->
+ * row row -> 1 or more fields field -> name and value
  *
  * See resources folder for sample meta data description files
  *
  */
 public class RFCMetaDataParser {
 
-    private static Log log = LogFactory.getLog(RFCMetaDataParser.class);
+	private static Log log = LogFactory.getLog(RFCMetaDataParser.class);
 
-    /**
-     * Start processing of the document
-     * @param document the document node
-     * @param function the RFC function to execute
-     * @throws AxisFault throws in case of an error
-     */
-    public static void processMetaDataDocument(OMElement document, JCoFunction function) throws AxisFault{
-        Iterator itr = document.getChildElements();
-        while(itr.hasNext()){
-            OMElement childElement = (OMElement)itr.next();
-            processElement(childElement, function);
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Processed metadata document");
-        }
-    }
+	/**
+	 * Start processing of the document
+	 * 
+	 * @param document
+	 *            the document node
+	 * @param function
+	 *            the RFC function to execute
+	 * @throws AxisFault
+	 *             throws in case of an error
+	 */
+	public static void processMetaDataDocument(OMElement document, JCoFunction function) throws AxisFault {
+		Iterator itr = document.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			processElement(childElement, function);
+		}
+		if (log.isDebugEnabled()) {
+			log.debug("Processed metadata document");
+		}
+	}
 
-    /**
-     * Returns the BAPI/RFC function name.
-     *
-     * @param rootElement root document element
-     * @return the BAPI/RFC function name
-     * @throws AxisFault throws in case of an error
-     */
-    public static String getBAPIRFCFunctionName(OMElement rootElement) throws AxisFault {
-        if (rootElement != null) {
-            String rfcFunctionName = rootElement.getAttributeValue(RFCConstants.NAME_Q);
-            if (rfcFunctionName != null) {
-                return rfcFunctionName;
-            } else {
-                throw new AxisFault("BAPI/RFC function name is mandatory in meta data configuration");
-            }
-        } else {
-            throw new AxisFault("Invalid meta data root element.Found: " + rootElement + "" +
-                                ". Required:" + RFCConstants.BAPIRFC);
-        }
-    }
+	/**
+	 * Returns the BAPI/RFC function name.
+	 *
+	 * @param rootElement
+	 *            root document element
+	 * @return the BAPI/RFC function name
+	 * @throws AxisFault
+	 *             throws in case of an error
+	 */
+	public static String getBAPIRFCFunctionName(OMElement rootElement) throws AxisFault {
+		if (rootElement != null) {
+			String rfcFunctionName = rootElement.getAttributeValue(RFCConstants.NAME_Q);
+			if (rfcFunctionName != null) {
+				return rfcFunctionName;
+			} else {
+				throw new AxisFault("BAPI/RFC function name is mandatory in meta data configuration");
+			}
+		} else {
+			throw new AxisFault(
+					"Invalid meta data root element.Found: " + rootElement + "" + ". Required:" + RFCConstants.BAPIRFC);
+		}
+	}
 
-    private static void processElement(OMElement element, JCoFunction function) throws AxisFault{
-        String qname = element.getQName().toString();
-        if(qname != null){
-            if(qname.equals("import")){
-                processImport(element, function);
-            }else if(qname.equals("tables")){
-                processTables(element, function);
-            }else {
-                log.warn("Unknown meta data type tag :" + qname + " detected. " +
-                        "This meta data element will be discarded!");
-            }
-        }
-    }
+	private static void processElement(OMElement element, JCoFunction function) throws AxisFault {
+		String qname = element.getQName().toString();
+		if (qname != null) {
+			if (qname.equals("import")) {
+				processImport(element, function);
+			} else if (qname.equals("tables")) {
+				processTables(element, function);
+			} else {
+				log.warn("Unknown meta data type tag :" + qname + " detected. "
+						+ "This meta data element will be discarded!");
+			}
+		}
+	}
 
-    private static void processImport(OMElement element, JCoFunction function) throws AxisFault{
-        Iterator itr = element.getChildElements();
-        while (itr.hasNext()){
-            OMElement childElement = (OMElement) itr.next();
-            String qname = childElement.getQName().toString();
-            String name = childElement.getAttributeValue(RFCConstants.NAME_Q);
-            if(qname.equals("structure")){
-                processStructure(childElement, function, name);
-            }else if(qname.equals("field")){
-                processField(childElement, function, name);
-            }else if(qname.equals("tables")){
-                processTablesParameter(childElement, function);
-            }else{
-                log.warn("Unknown meta data type tag :" + qname + " detected. " +
-                        "This meta data element will be discarded!");
-            }
-        }
-    }
+	private static void processImport(OMElement element, JCoFunction function) throws AxisFault {
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String name = childElement.getAttributeValue(RFCConstants.NAME_Q);
+			if (qname.equals("structure")) {
+				processStructure(childElement, function, name);
+			} else if (qname.equals("field")) {
+				processField(childElement, function, name);
+			} else if (qname.equals("tables")) {
+				processTablesParameter(childElement, function);
+			} else {
+				log.warn("Unknown meta data type tag :" + qname + " detected. "
+						+ "This meta data element will be discarded!");
+			}
+		}
+	}
 
-    private static void processStructure(OMElement element, JCoFunction function, String strcutName)
-            throws AxisFault {
-        if (strcutName == null) {
-            throw new AxisFault("A structure should have a name!");
-        }
-        JCoStructure jcoStrcture = function.getImportParameterList().getStructure(strcutName);
-        if (jcoStrcture != null) {
-            Iterator itr = element.getChildElements();
-            boolean isRecordFound = false;
-            while (itr.hasNext()) {
-                OMElement childElement = (OMElement) itr.next();
-                String qname = childElement.getQName().toString();
-                if (qname.equals("field")) {
-                    String fieldName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-                    String fieldValue = childElement.getText();
-                    for (JCoField field : jcoStrcture) {
-                        if (fieldName != null && fieldName.equals(field.getName())) {
-                            isRecordFound = true;
-                            field.setValue(fieldValue); // TODO - may be we need to check for null ?
-                            break;
-                        }
-                    }
-                    if(!isRecordFound){
-                        throw new AxisFault("Invalid configuration! The field : "+ fieldName + "" +
-                                " did not find the the strcture : " + strcutName);
-                    }
-                } else {
-                    log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
-                            "type will be ignored");
-                }
-            }
-        } else {
-            log.error("Didn't find the specified structure : " + strcutName + " on the RFC" +
-                    " repository. This structure will be ignored");
-        }
-    }
+	private static void processStructure(OMElement element, JCoFunction function, String strcutName) throws AxisFault {
+		if (strcutName == null) {
+			throw new AxisFault("A structure should have a name!");
+		}
+		JCoStructure jcoStrcture = function.getImportParameterList().getStructure(strcutName);
+		if (jcoStrcture != null) {
+			Iterator itr = element.getChildElements();
+			boolean isRecordFound = false;
+			while (itr.hasNext()) {
+				OMElement childElement = (OMElement) itr.next();
+				String qname = childElement.getQName().toString();
+				if (qname.equals("field")) {
+					String fieldName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+					String fieldValue = childElement.getText();
+					for (JCoField field : jcoStrcture) {
+						if (fieldName != null && fieldName.equals(field.getName())) {
+							isRecordFound = true;
+							field.setValue(fieldValue); // TODO - may be we need to check for null ?
+							break;
+						}
+					}
+					if (!isRecordFound) {
+						throw new AxisFault("Invalid configuration! The field : " + fieldName + ""
+								+ " did not find the the strcture : " + strcutName);
+					}
+				} else if (qname.equals("structure")) {
+					String structureName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+					JCoStructure jcoStructureInner = jcoStrcture.getStructure(structureName);
 
-    private static void processField(OMElement element, JCoFunction function, String fieldName)
-            throws AxisFault{
-        if(fieldName == null){
-            throw new AxisFault("A field should have a name!");
-        }
-        String fieldValue = element.getText();
-        if (fieldValue != null) {
-            // TODO-check for avalibility of the field
-            function.getImportParameterList().setValue(fieldName, fieldValue);
-        }
-    }
-    public static void processFieldValue(String fieldName, String fieldValue, JCoFunction function) throws AxisFault {
-        if (fieldValue != null) {
-            function.getImportParameterList().setValue(fieldName, fieldValue);
-        } else {
-            log.warn(fieldName + "is set with an empty value");
-        }
-    }
+					if (jcoStructureInner == null) {
+						throw new AxisFault("Invalid configuration! The structure : " + structureName + ""
+								+ " did not find the the strcture : " + strcutName);
+					}
 
-    private static void processTables(OMElement element, JCoFunction function) throws AxisFault{
-        Iterator itr = element.getChildElements();
-        while (itr.hasNext()){
-            OMElement childElement = (OMElement) itr.next();
-            String qname = childElement.getQName().toString();
-            String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-            if(qname.equals("table")){
-                processTable(childElement, function, tableName);
-            }else{
-                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
-                            "type will be ignored");
-            }
-        }
-    }
+					processStructure(childElement, jcoStructureInner, structureName);
+				} else if (qname.equals("table")) {
+					String name = childElement.getAttributeValue(new QName("name"));
+					JCoTable jcoTableInner = jcoStrcture.getTable(name);
+					processTable(childElement, jcoTableInner);
+				} else {
+					log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+							+ "type will be ignored");
+				}
+			}
+		} else {
+			log.error("Didn't find the specified structure : " + strcutName + " on the RFC"
+					+ " repository. This structure will be ignored");
+		}
+	}
 
-    private static void processTablesParameter(OMElement element, JCoFunction function) throws AxisFault{
-        Iterator itr = element.getChildElements();
-        while (itr.hasNext()){
-            OMElement childElement = (OMElement) itr.next();
-            String qname = childElement.getQName().toString();
-            String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-            if(qname.equals("table")){
-                processTableParameter(childElement, function, tableName);
-            }else{
-                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
-                            "type will be ignored");
-            }
-        }
-    }
+	private static void processStructure(OMElement element, JCoStructure jcoStrcture, String strcutName)
+			throws AxisFault {
+		if (jcoStrcture != null) {
+			Iterator itr = element.getChildElements();
+			boolean isRecordFound = false;
+			while (itr.hasNext()) {
+				OMElement childElement = (OMElement) itr.next();
+				String qname = childElement.getQName().toString();
+				if (qname.equals("field")) {
+					String fieldName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+					String fieldValue = childElement.getText();
+					for (JCoField field : jcoStrcture) {
+						if (fieldName != null && fieldName.equals(field.getName())) {
+							isRecordFound = true;
+							field.setValue(fieldValue); // TODO - may be we need to check for null ?
+							break;
+						}
+					}
+					if (!isRecordFound) {
+						throw new AxisFault("Invalid configuration! The field : " + fieldName + ""
+								+ " did not find the the strcture : " + strcutName);
+					}
+				} else if (qname.equals("structure")) {
+					String structureName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+					JCoStructure jcoStructureInner = jcoStrcture.getStructure(structureName);
 
-    private static void processTable(OMElement element, JCoFunction function, String tableName)
-            throws AxisFault{
-        JCoTable inputTable = function.getTableParameterList().getTable(tableName);
-        if(inputTable == null){
-            throw new AxisFault("Input table :" + tableName + " does not exist");
-        }
-        Iterator itr = element.getChildElements();
-        while (itr.hasNext()){
-            OMElement childElement = (OMElement)itr.next();
-            String qname = childElement.getQName().toString();
-            String id = childElement.getAttributeValue(RFCConstants.ID_Q);
-            if(qname.equals("row")){
-                processRow(childElement, inputTable, id);
-            }else{
-                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
-                            "type will be ignored");
-            }
+					if (jcoStructureInner == null) {
+						throw new AxisFault("Invalid configuration! The structure : " + structureName + ""
+								+ " did not find the the strcture : " + strcutName);
+					}
 
-        }
-    }
+					processStructure(childElement, jcoStructureInner, structureName);
+				} else if (qname.equals("table")) {
+					String tableName = childElement.getAttributeValue(new QName("name"));
+					JCoTable jcoTableInner = jcoStrcture.getTable(tableName);
 
-    private static void processTableParameter(OMElement element, JCoFunction function, String tableName)
-            throws AxisFault{
-        JCoTable inputTable = function.getImportParameterList().getTable(tableName);
-        if(inputTable == null){
-            throw new AxisFault("Input table parameter :" + tableName + " does not exist");
-        }
-        Iterator itr = element.getChildElements();
-        while (itr.hasNext()){
-            OMElement childElement = (OMElement)itr.next();
-            String qname = childElement.getQName().toString();
-            String id = childElement.getAttributeValue(RFCConstants.ID_Q);
-            if(qname.equals("row")){
-                processRow(childElement, inputTable, id);
-            }else{
-                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
-                            "type will be ignored");
-            }
+					if (jcoTableInner == null) {
+						throw new AxisFault("Invalid configuration! The table : " + tableName + ""
+								+ " did not find the the strcture : " + strcutName);
+					}
 
-        }
-    }
+					processTable(childElement, jcoTableInner);
+				} else {
+					log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+							+ "type will be ignored");
+				}
+			}
+		} else {
+			log.error("Didn't find the specified structure : " + strcutName + " on the RFC"
+					+ " repository. This structure will be ignored");
+		}
+	}
 
-    private static void processRow(OMElement element, JCoTable table, String id)
+	private static void processTable(OMElement element, JCoTable jconTable) {
+		JCoTable inputTable = jconTable;
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String id = childElement.getAttributeValue(new QName("id"));
+			if (qname.equals("row")) {
+				processRow(childElement, inputTable, id);
+			}
+
+		}
+	}
+
+	private static void processField(OMElement element, JCoFunction function, String fieldName) throws AxisFault {
+		if (fieldName == null) {
+			throw new AxisFault("A field should have a name!");
+		}
+		String fieldValue = element.getText();
+		if (fieldValue != null) {
+			// TODO-check for avalibility of the field
+			function.getImportParameterList().setValue(fieldName, fieldValue);
+		}
+	}
+
+	public static void processFieldValue(String fieldName, String fieldValue, JCoFunction function) throws AxisFault {
+		if (fieldValue != null) {
+			function.getImportParameterList().setValue(fieldName, fieldValue);
+		} else {
+			log.warn(fieldName + "is set with an empty value");
+		}
+	}
+
+	private static void processTables(OMElement element, JCoFunction function) throws AxisFault {
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+			if (qname.equals("table")) {
+				processTable(childElement, function, tableName);
+			} else {
+				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+						+ "type will be ignored");
+			}
+		}
+	}
+
+	private static void processTablesParameter(OMElement element, JCoFunction function) throws AxisFault {
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+			if (qname.equals("table")) {
+				processTableParameter(childElement, function, tableName);
+			} else {
+				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+						+ "type will be ignored");
+			}
+		}
+	}
+
+	private static void processTable(OMElement element, JCoFunction function, String tableName) throws AxisFault {
+		JCoTable inputTable = function.getTableParameterList().getTable(tableName);
+		if (inputTable == null) {
+			throw new AxisFault("Input table :" + tableName + " does not exist");
+		}
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String id = childElement.getAttributeValue(RFCConstants.ID_Q);
+			if (qname.equals("row")) {
+				processRow(childElement, inputTable, id);
+			} else {
+				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+						+ "type will be ignored");
+			}
+
+		}
+	}
+
+	private static void processTableParameter(OMElement element, JCoFunction function, String tableName)
+			throws AxisFault {
+		JCoTable inputTable = function.getImportParameterList().getTable(tableName);
+		if (inputTable == null) {
+			throw new AxisFault("Input table parameter :" + tableName + " does not exist");
+		}
+		Iterator itr = element.getChildElements();
+		while (itr.hasNext()) {
+			OMElement childElement = (OMElement) itr.next();
+			String qname = childElement.getQName().toString();
+			String id = childElement.getAttributeValue(RFCConstants.ID_Q);
+			if (qname.equals("row")) {
+				processRow(childElement, inputTable, id);
+			} else {
+				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
+						+ "type will be ignored");
+			}
+
+		}
+	}
+
+	private static void processRow(OMElement element, JCoTable table, String id)
             throws AxisFault {
 
         int rowId;
@@ -268,24 +349,33 @@ public class RFCMetaDataParser {
             OMElement childElement = (OMElement) itr.next();
             String qname = childElement.getQName().toString();
             if (qname != null && qname.equals("field")) {
-                processField(childElement, table);
-            } else {
+                processField(childElement, table);                
+            } else if (qname != null && qname.equals("structure")) {
+				String structureName = childElement.getAttributeValue(new QName("name"));
+				JCoStructure jcoStrctureInner = table.getStructure(structureName);
+				
+				if (jcoStrctureInner != null) {
+					processStructure(childElement, jcoStrctureInner, structureName);
+				}else {
+	                log.warn("Invalid meta data type element found : " + structureName + " .This meta data " +
+	                        "type will be ignored");					
+				}
+			} else {
                 log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
                         "type will be ignored");
             }
         }
     }
 
-    private static void processField(OMElement element, JCoTable table)
-            throws AxisFault {
-        String fieldName = element.getAttributeValue(RFCConstants.NAME_Q);
-        String fieldValue = element.getText();
+	private static void processField(OMElement element, JCoTable table) throws AxisFault {
+		String fieldName = element.getAttributeValue(RFCConstants.NAME_Q);
+		String fieldValue = element.getText();
 
-        if (fieldName == null) {
-            throw new AxisFault("A field should have a name!");
-        }
-        if (fieldValue != null) {
-            table.setValue(fieldName, fieldValue);
-        }
-    }
+		if (fieldName == null) {
+			throw new AxisFault("A field should have a name!");
+		}
+		if (fieldValue != null) {
+			table.setValue(fieldName, fieldValue);
+		}
+	}
 }

--- a/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
+++ b/components/sap/src/main/java/org/wso2/carbon/transports/sap/bapi/util/RFCMetaDataParser.java
@@ -26,123 +26,122 @@ import org.apache.commons.logging.LogFactory;
 
 import java.util.Iterator;
 
-/**
- * This will contain the required methods that can be use to parser a meta data
- * description of a BAPI/RFC call. So the BNF grammer for the meta data would
- * looks like : bapirfc -> import | tables | both import -> structure | field |
- * tables | all structure -> 1 or more fields tables -> 1 or more table table ->
- * row row -> 1 or more fields field -> name and value
+/** This will contain the required methods that can be use to parser a
+ * meta data description of a BAPI/RFC call.
+ * So the BNF grammer for the meta data would looks like :
+ *  bapirfc   -> import | tables | both
+ *  import    -> structure | field | tables | all
+ *  structure -> 1 or more fields
+ *  tables    -> 1 or more table
+ *  table     -> row
+ *  row       -> 1 or more fields
+ *  field     -> name and value
  *
  * See resources folder for sample meta data description files
  *
  */
 public class RFCMetaDataParser {
 
-	private static Log log = LogFactory.getLog(RFCMetaDataParser.class);
+    private static Log log = LogFactory.getLog(RFCMetaDataParser.class);
 
-	/**
-	 * Start processing of the document
-	 * 
-	 * @param document
-	 *            the document node
-	 * @param function
-	 *            the RFC function to execute
-	 * @throws AxisFault
-	 *             throws in case of an error
-	 */
-	public static void processMetaDataDocument(OMElement document, JCoFunction function) throws AxisFault {
-		Iterator itr = document.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			processElement(childElement, function);
-		}
-		if (log.isDebugEnabled()) {
-			log.debug("Processed metadata document");
-		}
-	}
+    /**
+     * Start processing of the document
+     * @param document the document node
+     * @param function the RFC function to execute
+     * @throws AxisFault throws in case of an error
+     */
+    public static void processMetaDataDocument(OMElement document, JCoFunction function) throws AxisFault{
+        Iterator itr = document.getChildElements();
+        while(itr.hasNext()){
+            OMElement childElement = (OMElement)itr.next();
+            processElement(childElement, function);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Processed metadata document");
+        }
+    }
 
-	/**
-	 * Returns the BAPI/RFC function name.
-	 *
-	 * @param rootElement
-	 *            root document element
-	 * @return the BAPI/RFC function name
-	 * @throws AxisFault
-	 *             throws in case of an error
-	 */
-	public static String getBAPIRFCFunctionName(OMElement rootElement) throws AxisFault {
-		if (rootElement != null) {
-			String rfcFunctionName = rootElement.getAttributeValue(RFCConstants.NAME_Q);
-			if (rfcFunctionName != null) {
-				return rfcFunctionName;
-			} else {
-				throw new AxisFault("BAPI/RFC function name is mandatory in meta data configuration");
-			}
-		} else {
-			throw new AxisFault(
-					"Invalid meta data root element.Found: " + rootElement + "" + ". Required:" + RFCConstants.BAPIRFC);
-		}
-	}
+    /**
+     * Returns the BAPI/RFC function name.
+     *
+     * @param rootElement root document element
+     * @return the BAPI/RFC function name
+     * @throws AxisFault throws in case of an error
+     */
+    public static String getBAPIRFCFunctionName(OMElement rootElement) throws AxisFault {
+        if (rootElement != null) {
+            String rfcFunctionName = rootElement.getAttributeValue(RFCConstants.NAME_Q);
+            if (rfcFunctionName != null) {
+                return rfcFunctionName;
+            } else {
+                throw new AxisFault("BAPI/RFC function name is mandatory in meta data configuration");
+            }
+        } else {
+            throw new AxisFault("Invalid meta data root element.Found: " + rootElement + "" +
+                                ". Required:" + RFCConstants.BAPIRFC);
+        }
+    }
 
-	private static void processElement(OMElement element, JCoFunction function) throws AxisFault {
-		String qname = element.getQName().toString();
-		if (qname != null) {
-			if (qname.equals("import")) {
-				processImport(element, function);
-			} else if (qname.equals("tables")) {
-				processTables(element, function);
-			} else {
-				log.warn("Unknown meta data type tag :" + qname + " detected. "
-						+ "This meta data element will be discarded!");
-			}
-		}
-	}
+    private static void processElement(OMElement element, JCoFunction function) throws AxisFault{
+        String qname = element.getQName().toString();
+        if(qname != null){
+            if(qname.equals("import")){
+                processImport(element, function);
+            }else if(qname.equals("tables")){
+                processTables(element, function);
+            }else {
+                log.warn("Unknown meta data type tag :" + qname + " detected. " +
+                        "This meta data element will be discarded!");
+            }
+        }
+    }
 
-	private static void processImport(OMElement element, JCoFunction function) throws AxisFault {
-		Iterator itr = element.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			String qname = childElement.getQName().toString();
-			String name = childElement.getAttributeValue(RFCConstants.NAME_Q);
-			if (qname.equals("structure")) {
-				processStructure(childElement, function, name);
-			} else if (qname.equals("field")) {
-				processField(childElement, function, name);
-			} else if (qname.equals("tables")) {
-				processTablesParameter(childElement, function);
-			} else {
-				log.warn("Unknown meta data type tag :" + qname + " detected. "
-						+ "This meta data element will be discarded!");
-			}
-		}
-	}
+    private static void processImport(OMElement element, JCoFunction function) throws AxisFault{
+        Iterator itr = element.getChildElements();
+        while (itr.hasNext()){
+            OMElement childElement = (OMElement) itr.next();
+            String qname = childElement.getQName().toString();
+            String name = childElement.getAttributeValue(RFCConstants.NAME_Q);
+            if(qname.equals("structure")){
+                processStructure(childElement, function, name);
+            }else if(qname.equals("field")){
+                processField(childElement, function, name);
+            }else if(qname.equals("tables")){
+                processTablesParameter(childElement, function);
+            }else{
+                log.warn("Unknown meta data type tag :" + qname + " detected. " +
+                        "This meta data element will be discarded!");
+            }
+        }
+    }
 
-	private static void processStructure(OMElement element, JCoFunction function, String strcutName) throws AxisFault {
-		if (strcutName == null) {
-			throw new AxisFault("A structure should have a name!");
-		}
-		JCoStructure jcoStrcture = function.getImportParameterList().getStructure(strcutName);
-		if (jcoStrcture != null) {
-			Iterator itr = element.getChildElements();
-			boolean isRecordFound = false;
-			while (itr.hasNext()) {
-				OMElement childElement = (OMElement) itr.next();
-				String qname = childElement.getQName().toString();
-				if (qname.equals("field")) {
-					String fieldName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-					String fieldValue = childElement.getText();
-					for (JCoField field : jcoStrcture) {
-						if (fieldName != null && fieldName.equals(field.getName())) {
-							isRecordFound = true;
-							field.setValue(fieldValue); // TODO - may be we need to check for null ?
-							break;
-						}
-					}
-					if (!isRecordFound) {
-						throw new AxisFault("Invalid configuration! The field : " + fieldName + ""
-								+ " did not find the the strcture : " + strcutName);
-					}
-				} else if (qname.equals("structure")) {
+    private static void processStructure(OMElement element, JCoFunction function, String strcutName)
+            throws AxisFault {
+        if (strcutName == null) {
+            throw new AxisFault("A structure should have a name!");
+        }
+        JCoStructure jcoStrcture = function.getImportParameterList().getStructure(strcutName);
+        if (jcoStrcture != null) {
+            Iterator itr = element.getChildElements();
+            boolean isRecordFound = false;
+            while (itr.hasNext()) {
+                OMElement childElement = (OMElement) itr.next();
+                String qname = childElement.getQName().toString();
+                if (qname.equals("field")) {
+                    String fieldName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+                    String fieldValue = childElement.getText();
+                    for (JCoField field : jcoStrcture) {
+                        if (fieldName != null && fieldName.equals(field.getName())) {
+                            isRecordFound = true;
+                            field.setValue(fieldValue); // TODO - may be we need to check for null ?
+                            break;
+                        }
+                    }
+                    if(!isRecordFound){
+                        throw new AxisFault("Invalid configuration! The field : "+ fieldName + "" +
+                                " did not find the the strcture : " + strcutName);
+                    }
+                } else if (qname.equals("structure")) {
 					String structureName = childElement.getAttributeValue(RFCConstants.NAME_Q);
 					JCoStructure jcoStructureInner = jcoStrcture.getStructure(structureName);
 
@@ -157,15 +156,15 @@ public class RFCMetaDataParser {
 					JCoTable jcoTableInner = jcoStrcture.getTable(name);
 					processTable(childElement, jcoTableInner);
 				} else {
-					log.warn("Invalid meta data type element found : " + qname + " .This meta data "
-							+ "type will be ignored");
-				}
-			}
-		} else {
-			log.error("Didn't find the specified structure : " + strcutName + " on the RFC"
-					+ " repository. This structure will be ignored");
-		}
-	}
+                    log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
+                            "type will be ignored");
+                }
+            }
+        } else {
+            log.error("Didn't find the specified structure : " + strcutName + " on the RFC" +
+                    " repository. This structure will be ignored");
+        }
+    }
 
 	private static void processStructure(OMElement element, JCoStructure jcoStrcture, String strcutName)
 			throws AxisFault {
@@ -234,97 +233,98 @@ public class RFCMetaDataParser {
 		}
 	}
 
-	private static void processField(OMElement element, JCoFunction function, String fieldName) throws AxisFault {
-		if (fieldName == null) {
-			throw new AxisFault("A field should have a name!");
-		}
-		String fieldValue = element.getText();
-		if (fieldValue != null) {
-			// TODO-check for avalibility of the field
-			function.getImportParameterList().setValue(fieldName, fieldValue);
-		}
-	}
+    private static void processField(OMElement element, JCoFunction function, String fieldName)
+            throws AxisFault{
+        if(fieldName == null){
+            throw new AxisFault("A field should have a name!");
+        }
+        String fieldValue = element.getText();
+        if (fieldValue != null) {
+            // TODO-check for avalibility of the field
+            function.getImportParameterList().setValue(fieldName, fieldValue);
+        }
+    }
+    public static void processFieldValue(String fieldName, String fieldValue, JCoFunction function) throws AxisFault {
+        if (fieldValue != null) {
+            function.getImportParameterList().setValue(fieldName, fieldValue);
+        } else {
+            log.warn(fieldName + "is set with an empty value");
+        }
+    }
 
-	public static void processFieldValue(String fieldName, String fieldValue, JCoFunction function) throws AxisFault {
-		if (fieldValue != null) {
-			function.getImportParameterList().setValue(fieldName, fieldValue);
-		} else {
-			log.warn(fieldName + "is set with an empty value");
-		}
-	}
+    private static void processTables(OMElement element, JCoFunction function) throws AxisFault{
+        Iterator itr = element.getChildElements();
+        while (itr.hasNext()){
+            OMElement childElement = (OMElement) itr.next();
+            String qname = childElement.getQName().toString();
+            String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+            if(qname.equals("table")){
+                processTable(childElement, function, tableName);
+            }else{
+                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
+                            "type will be ignored");
+            }
+        }
+    }
 
-	private static void processTables(OMElement element, JCoFunction function) throws AxisFault {
-		Iterator itr = element.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			String qname = childElement.getQName().toString();
-			String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-			if (qname.equals("table")) {
-				processTable(childElement, function, tableName);
-			} else {
-				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
-						+ "type will be ignored");
-			}
-		}
-	}
+    private static void processTablesParameter(OMElement element, JCoFunction function) throws AxisFault{
+        Iterator itr = element.getChildElements();
+        while (itr.hasNext()){
+            OMElement childElement = (OMElement) itr.next();
+            String qname = childElement.getQName().toString();
+            String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
+            if(qname.equals("table")){
+                processTableParameter(childElement, function, tableName);
+            }else{
+                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
+                            "type will be ignored");
+            }
+        }
+    }
 
-	private static void processTablesParameter(OMElement element, JCoFunction function) throws AxisFault {
-		Iterator itr = element.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			String qname = childElement.getQName().toString();
-			String tableName = childElement.getAttributeValue(RFCConstants.NAME_Q);
-			if (qname.equals("table")) {
-				processTableParameter(childElement, function, tableName);
-			} else {
-				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
-						+ "type will be ignored");
-			}
-		}
-	}
+    private static void processTable(OMElement element, JCoFunction function, String tableName)
+            throws AxisFault{
+        JCoTable inputTable = function.getTableParameterList().getTable(tableName);
+        if(inputTable == null){
+            throw new AxisFault("Input table :" + tableName + " does not exist");
+        }
+        Iterator itr = element.getChildElements();
+        while (itr.hasNext()){
+            OMElement childElement = (OMElement)itr.next();
+            String qname = childElement.getQName().toString();
+            String id = childElement.getAttributeValue(RFCConstants.ID_Q);
+            if(qname.equals("row")){
+                processRow(childElement, inputTable, id);
+            }else{
+                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
+                            "type will be ignored");
+            }
 
-	private static void processTable(OMElement element, JCoFunction function, String tableName) throws AxisFault {
-		JCoTable inputTable = function.getTableParameterList().getTable(tableName);
-		if (inputTable == null) {
-			throw new AxisFault("Input table :" + tableName + " does not exist");
-		}
-		Iterator itr = element.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			String qname = childElement.getQName().toString();
-			String id = childElement.getAttributeValue(RFCConstants.ID_Q);
-			if (qname.equals("row")) {
-				processRow(childElement, inputTable, id);
-			} else {
-				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
-						+ "type will be ignored");
-			}
+        }
+    }
 
-		}
-	}
+    private static void processTableParameter(OMElement element, JCoFunction function, String tableName)
+            throws AxisFault{
+        JCoTable inputTable = function.getImportParameterList().getTable(tableName);
+        if(inputTable == null){
+            throw new AxisFault("Input table parameter :" + tableName + " does not exist");
+        }
+        Iterator itr = element.getChildElements();
+        while (itr.hasNext()){
+            OMElement childElement = (OMElement)itr.next();
+            String qname = childElement.getQName().toString();
+            String id = childElement.getAttributeValue(RFCConstants.ID_Q);
+            if(qname.equals("row")){
+                processRow(childElement, inputTable, id);
+            }else{
+                log.warn("Invalid meta data type element found : " + qname + " .This meta data " +
+                            "type will be ignored");
+            }
 
-	private static void processTableParameter(OMElement element, JCoFunction function, String tableName)
-			throws AxisFault {
-		JCoTable inputTable = function.getImportParameterList().getTable(tableName);
-		if (inputTable == null) {
-			throw new AxisFault("Input table parameter :" + tableName + " does not exist");
-		}
-		Iterator itr = element.getChildElements();
-		while (itr.hasNext()) {
-			OMElement childElement = (OMElement) itr.next();
-			String qname = childElement.getQName().toString();
-			String id = childElement.getAttributeValue(RFCConstants.ID_Q);
-			if (qname.equals("row")) {
-				processRow(childElement, inputTable, id);
-			} else {
-				log.warn("Invalid meta data type element found : " + qname + " .This meta data "
-						+ "type will be ignored");
-			}
+        }
+    }
 
-		}
-	}
-
-	private static void processRow(OMElement element, JCoTable table, String id)
+    private static void processRow(OMElement element, JCoTable table, String id)
             throws AxisFault {
 
         int rowId;
@@ -349,7 +349,7 @@ public class RFCMetaDataParser {
             OMElement childElement = (OMElement) itr.next();
             String qname = childElement.getQName().toString();
             if (qname != null && qname.equals("field")) {
-                processField(childElement, table);                
+                processField(childElement, table);
             } else if (qname != null && qname.equals("structure")) {
 				String structureName = childElement.getAttributeValue(new QName("name"));
 				JCoStructure jcoStrctureInner = table.getStructure(structureName);
@@ -367,15 +367,16 @@ public class RFCMetaDataParser {
         }
     }
 
-	private static void processField(OMElement element, JCoTable table) throws AxisFault {
-		String fieldName = element.getAttributeValue(RFCConstants.NAME_Q);
-		String fieldValue = element.getText();
+    private static void processField(OMElement element, JCoTable table)
+            throws AxisFault {
+        String fieldName = element.getAttributeValue(RFCConstants.NAME_Q);
+        String fieldValue = element.getText();
 
-		if (fieldName == null) {
-			throw new AxisFault("A field should have a name!");
-		}
-		if (fieldValue != null) {
-			table.setValue(fieldName, fieldValue);
-		}
-	}
+        if (fieldName == null) {
+            throw new AxisFault("A field should have a name!");
+        }
+        if (fieldValue != null) {
+            table.setValue(fieldName, fieldValue);
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
> To allow  the use of deep structures in the import parameter it is necessary to evaluate all the different node types

```
<bapirfc name="ZF_DEMO_BASE" xmlns="">
	<import>
		<structure name="ENTRY">
			<field name="STRINGFIELD">StringField</field>
			<table name="TABLE_AT_BEGIN">
				<row id="0">
					<field name="CHARFIELD">CharField</field>
					<structure name="CHANGEDFIELD">
						<field name="CHECKENTRY">CheckEntry</field>
					</structure>
				</row>
			</table>
			<structure name="CHANGEDFIELD">
				<field name="CHECKENTRY">CheckEntry</field>
			</structure>										
		</structure>
	</import>
</bapirfc>
```

## Goals
> Based on the code it is possible to nest structures inside structures , tables inside strutures and structures inside tables